### PR TITLE
Enable a local application config file

### DIFF
--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,1 +1,3 @@
+application.config.local.php
 compass.rb
+

--- a/config/application.config.local.php.dist
+++ b/config/application.config.local.php.dist
@@ -1,0 +1,6 @@
+<?php
+return array(
+    'modules' => array(
+        'Soflomo\StagingBar',
+    ),
+);

--- a/config/application.config.php
+++ b/config/application.config.php
@@ -1,5 +1,8 @@
 <?php
-return array(
+
+use Zend\Stdlib\ArrayUtils;
+
+$config = array(
     'modules' => array(
         'Application',
         'Soflomo\Prototype',
@@ -16,3 +19,11 @@ return array(
         ),
     ),
 );
+
+$local = __DIR__ . '/application.config.local.php';
+if (is_readable($local)) {
+    $config = ArrayUtils::merge($config, require($local));
+}
+
+return $config;
+


### PR DESCRIPTION
When the .dist file is used to create a local application config,
it is possible to load modules and specify caching options per
installation.
