### PR TITLE
Fix incorrect naming of the project in JSON

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "--Project Name--",
+  "name": "project-name",
   "version": "0.1.0",
   "main": "./public/styles/css/styles.css",
   "dependencies": {


### PR DESCRIPTION
Bower does not accept a naming formaat "--Project Name--" and as
such will not run when the name is not replaced. "project-name" is
accepted though so it will always run.
